### PR TITLE
Comparison async in every operator by trigger vs one control operator with only one event loop

### DIFF
--- a/dags/async_benchmark_asyncio.py
+++ b/dags/async_benchmark_asyncio.py
@@ -1,0 +1,208 @@
+"""
+AsyncIO-based Async Benchmark DAG
+
+This DAG uses traditional asyncio with async queues to perform file I/O operations.
+It measures the performance of asyncio approach for comparison with defer mechanism.
+"""
+
+import asyncio
+import time
+from datetime import datetime
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor
+
+from airflow import DAG
+from airflow.providers.standard.operators.python import PythonOperator
+
+
+async def async_file_write(file_path: str, content: str, delay: float = 0.1):
+    """Async function to write file with artificial delay."""
+    start_time = time.time()
+
+    # Simulate async I/O operation
+    await asyncio.sleep(delay)
+
+    # Write file asynchronously
+    path = Path(file_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        import aiofiles
+        async with aiofiles.open(file_path, 'w') as f:
+            await f.write(content)
+    except ImportError:
+        # Fallback to thread pool for file I/O if aiofiles not available
+        loop = asyncio.get_event_loop()
+        with ThreadPoolExecutor() as executor:
+            await loop.run_in_executor(executor, _sync_write_file, file_path, content)
+
+    end_time = time.time()
+
+    return {
+        "status": "success",
+        "file_path": file_path,
+        "execution_time": end_time - start_time,
+        "content_length": len(content),
+    }
+
+
+def _sync_write_file(file_path: str, content: str):
+    """Helper function for sync file write."""
+    with open(file_path, 'w') as f:
+        f.write(content)
+
+
+async def process_file_queue(queue: asyncio.Queue, results: list):
+    """Worker coroutine to process file operations from queue."""
+    while True:
+        try:
+            # Get task from queue with timeout
+            task_data = await asyncio.wait_for(queue.get(), timeout=1.0)
+            if task_data is None:  # Sentinel value to stop
+                break
+
+            file_path, content, delay = task_data
+            result = await async_file_write(file_path, content, delay)
+            results.append(result)
+            queue.task_done()
+
+        except asyncio.TimeoutError:
+            break
+        except Exception as e:
+            print(f"Error processing file operation: {e}")
+            queue.task_done()
+
+
+def run_asyncio_benchmark(**context):
+    """Run the asyncio-based benchmark."""
+    start_time = time.time()
+
+    # Configuration
+    num_operations = 10
+    num_workers = 5  # Number of async workers
+    base_path = "/Users/alexgo/code/airflow/benchmark_output/asyncio"
+
+    async def main():
+        # Create queue and results list
+        queue = asyncio.Queue()
+        results = []
+
+        # Start worker coroutines
+        workers = [
+            asyncio.create_task(process_file_queue(queue, results))
+            for _ in range(num_workers)
+        ]
+
+        # Add tasks to queue
+        for i in range(num_operations):
+            content = f"AsyncIO-based async operation {i+1}\n" + "x" * 1000  # 1KB content
+            file_path = f"{base_path}/file_{i+1:03d}.txt"
+            await queue.put((file_path, content, 0.5))  # Half second delay
+
+        # Wait for all tasks to complete
+        await queue.join()
+
+        # Stop workers
+        for _ in workers:
+            await queue.put(None)  # Sentinel values
+
+        # Wait for workers to finish
+        await asyncio.gather(*workers, return_exceptions=True)
+
+        return results
+
+    # Run the async operations
+    try:
+        # Check if we're already in an event loop
+        loop = asyncio.get_running_loop()
+        # If we are, we need to run in a new thread
+        import concurrent.futures
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            future = executor.submit(asyncio.run, main())
+            results = future.result()
+    except RuntimeError:
+        # No event loop running, safe to use asyncio.run
+        results = asyncio.run(main())
+
+    end_time = time.time()
+    total_time = end_time - start_time
+
+    # Calculate statistics
+    avg_time = sum(r['execution_time'] for r in results) / len(results) if results else 0
+
+    summary = {
+        'approach': 'asyncio',
+        'num_operations': len(results),
+        'total_time': total_time,
+        'avg_time_per_op': avg_time,
+        'operations_per_second': len(results) / total_time if total_time > 0 else 0,
+        'num_workers': num_workers,
+    }
+
+    print(f"=== ASYNCIO BENCHMARK RESULTS ===")
+    print(f"Operations: {summary['num_operations']}")
+    print(f"Workers: {summary['num_workers']}")
+    print(f"Total time: {summary['total_time']:.4f}s")
+    print(f"Avg time per op: {summary['avg_time_per_op']:.4f}s")
+    print(f"Operations/sec: {summary['operations_per_second']:.2f}")
+    print(f"==================================")
+
+    return summary
+
+
+def compare_results(**context):
+    """Compare results from both approaches."""
+    asyncio_result = context['task_instance'].xcom_pull(task_ids='run_asyncio_benchmark')
+
+    print(f"\n=== BENCHMARK COMPARISON ===")
+    print(f"AsyncIO Approach:")
+    print(f"  Total time: {asyncio_result['total_time']:.4f}s")
+    print(f"  Operations/sec: {asyncio_result['operations_per_second']:.2f}")
+    print(f"  Avg time per op: {asyncio_result['avg_time_per_op']:.4f}s")
+    print(f"===========================")
+
+    return {
+        'asyncio_results': asyncio_result,
+        'comparison_notes': 'Run both DAGs to see full comparison'
+    }
+
+
+# DAG definition
+default_args = {
+    'owner': 'benchmark',
+    'depends_on_past': False,
+    'start_date': datetime(2025, 1, 1),
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 0,
+}
+
+with DAG(
+    dag_id='async_benchmark_asyncio',
+    default_args=default_args,
+    description='Async benchmark using AsyncIO and queues',
+    schedule=None,
+    catchup=False,
+    max_active_runs=1,
+    tags=['benchmark', 'async', 'asyncio'],
+) as dag:
+
+    # Single task that runs all async operations using asyncio
+    asyncio_task = PythonOperator(
+        task_id='run_asyncio_benchmark',
+        python_callable=run_asyncio_benchmark,
+    )
+
+    # Summary and comparison task
+    compare_task = PythonOperator(
+        task_id='compare_results',
+        python_callable=compare_results,
+    )
+
+    asyncio_task >> compare_task
+
+
+# Test the DAG when run directly
+if __name__ == "__main__":
+    print("Testing AsyncIO benchmark DAG...")
+    dag.test()

--- a/dags/async_benchmark_defer.py
+++ b/dags/async_benchmark_defer.py
@@ -1,0 +1,143 @@
+"""
+Airflow Defer-based Async Benchmark DAG
+
+This DAG uses Airflow's defer/trigger mechanism to perform async file I/O operations.
+It measures the performance of deferred operations for comparison with asyncio approach.
+"""
+
+import time
+from datetime import datetime
+
+from airflow import DAG
+from airflow.models import BaseOperator
+from airflow.utils.context import Context
+from async_file_triggers import AsyncFileWriteTrigger
+#from async_file_triggers_lessblocking import AsyncFileWriteTrigger
+
+
+class DeferFileWriteOperator(BaseOperator):
+    """Operator that uses defer mechanism for async file operations."""
+
+    def __init__(self, file_path: str, content: str, delay: float = 0.1, **kwargs):
+        super().__init__(**kwargs)
+        self.file_path = file_path
+        self.content = content
+        self.delay = delay
+
+    def execute(self, context: Context):
+        """Start the deferred async operation."""
+        start_time = time.time()
+        context['task_instance'].xcom_push(key='start_time', value=start_time)
+
+        self.log.info(f"Starting deferred file write to {self.file_path}")
+
+        self.defer(
+            trigger=AsyncFileWriteTrigger(
+                file_path=self.file_path,
+                content=self.content,
+                delay=self.delay,
+            ),
+            method_name="execute_complete",
+        )
+
+    def execute_complete(self, context: Context, event: dict):
+        """Complete the deferred operation."""
+        start_time = context['task_instance'].xcom_pull(key='start_time')
+        total_time = time.time() - start_time
+
+        self.log.info(f"Deferred file write completed in {total_time:.4f}s")
+        self.log.info(f"Trigger execution time: {event['execution_time']:.4f}s")
+
+        return {
+            "status": event["status"],
+            "file_path": event["file_path"],
+            "trigger_time": event["execution_time"],
+            "total_time": total_time,
+            "content_length": event["content_length"],
+        }
+
+
+# DAG definition
+default_args = {
+    'owner': 'benchmark',
+    'depends_on_past': False,
+    'start_date': datetime(2025, 1, 1),
+    'email_on_failure': False,
+    'email_on_retry': False,
+    'retries': 0,
+}
+
+with DAG(
+    dag_id='async_benchmark_defer',
+    default_args=default_args,
+    description='Async benchmark using Airflow defer mechanism',
+    schedule=None,
+    catchup=False,
+    max_active_runs=1,
+    tags=['benchmark', 'async', 'defer'],
+) as dag:
+
+    # Create multiple file write operations to test concurrency
+    write_ops = []
+    num_operations = 10
+    base_path = "/Users/alexgo/code/airflow/benchmark_output/defer"
+
+    for i in range(num_operations):
+        content = f"Defer-based async operation {i+1}\n" + "x" * 1000  # 1KB content
+        file_path = f"{base_path}/file_{i+1:03d}.txt"
+
+        op = DeferFileWriteOperator(
+            task_id=f'defer_write_{i+1:03d}',
+            file_path=file_path,
+            content=content,
+            delay=0.5,  # Half second delay to simulate I/O
+        )
+        write_ops.append(op)
+
+    # Create a summary task
+    from airflow.providers.standard.operators.python import PythonOperator
+
+    def summarize_results(**context):
+        """Collect and summarize benchmark results."""
+        results = []
+        total_time = 0
+
+        for i in range(num_operations):
+            task_id = f'defer_write_{i+1:03d}'
+            result = context['task_instance'].xcom_pull(task_ids=task_id)
+            if result:
+                results.append(result)
+                total_time += result['total_time']
+
+        avg_time = total_time / len(results) if results else 0
+
+        summary = {
+            'approach': 'defer',
+            'num_operations': len(results),
+            'total_time': total_time,
+            'avg_time_per_op': avg_time,
+            'operations_per_second': len(results) / total_time if total_time > 0 else 0,
+        }
+
+        print(f"=== DEFER BENCHMARK RESULTS ===")
+        print(f"Operations: {summary['num_operations']}")
+        print(f"Total time: {summary['total_time']:.4f}s")
+        print(f"Avg time per op: {summary['avg_time_per_op']:.4f}s")
+        print(f"Operations/sec: {summary['operations_per_second']:.2f}")
+        print(f"===============================")
+
+        return summary
+
+    summary_task = PythonOperator(
+        task_id='summarize_defer_results',
+        python_callable=summarize_results,
+    )
+
+    # Set up dependencies - all write operations run in parallel, then summary
+    write_ops >> summary_task
+
+
+# Test the DAG when run directly
+if __name__ == "__main__":
+    print("Testing Defer benchmark DAG...")
+    dag.test()

--- a/plugins/async_file_triggers.py
+++ b/plugins/async_file_triggers.py
@@ -1,0 +1,61 @@
+"""
+Custom triggers for async file operations.
+This module is in plugins/ so Airflow can properly import and deserialize triggers.
+"""
+
+import asyncio
+import time
+from pathlib import Path
+from typing import Any
+
+from airflow.triggers.base import TriggerEvent, BaseTrigger
+
+
+class AsyncFileWriteTrigger(BaseTrigger):
+    """Custom trigger that performs async file write operations."""
+
+    def __init__(self, file_path: str, content: str, delay: float = 0.1):
+        super().__init__()
+        self.file_path = file_path
+        self.content = content
+        self.delay = delay
+
+    def serialize(self) -> tuple[str, dict[str, Any]]:
+        return (
+            "async_file_triggers.AsyncFileWriteTrigger",
+            {
+                "file_path": self.file_path,
+                "content": self.content,
+                "delay": self.delay,
+            },
+        )
+
+    async def run(self):
+        """Perform async file write with artificial delay."""
+        start_time = time.time()
+
+        # Simulate async I/O operation
+        await asyncio.sleep(self.delay)
+
+        # Write file asynchronously
+        path = Path(self.file_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Use aiofiles for truly async file operations
+        try:
+            import aiofiles
+            async with aiofiles.open(self.file_path, 'w') as f:
+                await f.write(self.content)
+        except ImportError:
+            # Fallback to sync write if aiofiles not available
+            with open(self.file_path, 'w') as f:
+                f.write(self.content)
+
+        end_time = time.time()
+
+        yield TriggerEvent({
+            "status": "success",
+            "file_path": self.file_path,
+            "execution_time": end_time - start_time,
+            "content_length": len(self.content),
+        })


### PR DESCRIPTION
So just to see if conceptually this makes sense. I ran in one experiment only one airflow task with one asyncio event loop and in another experiment multiple operators each one with a trigger to perform async on the trigger host. I don't think we should put much trust into these results since I might measure other contributions of the timing like airflow overhead, also I don't know if the examples are comparable, since I generated them by LLM and only went over the code quickly. At least the direction of the timings make sense. One operator ~2s , multiple operators with 2 triggerer instances ~6s. I think one should test how this scales if we really do many operations in the trigger. Here I am just writing one file with this content `f"Debug defer operation {i+1}\n" + "x" * 100`.

### `dags/async_benchmark_defer.py`
Runs 10 asyncio operations within 10 airflow task within multiple event loops (can be controlled with the number of triggerer). I tested 2-3 triggerer event loops.
<img  width="300" alt="async_benchmark_defer" src="https://github.com/user-attachments/assets/a8203d87-9bb9-499d-85da-949f2b5baddc" />

### `dags/async_benchmark_asyncio.py`
Runs 10 asyncio operations within 1 airflow task within 1 event loop. There is another layer of complexity that might need to be removed for clear comparison. There are only 5 coroutines (`num_workers`) that process the 10 asyncio operations while in principle. I don't feel like it makes a huge difference but it should be checked still carefully for a real comparison.
<img width="300" height="348" alt="async_benchmark_asyncio" src="https://github.com/user-attachments/assets/ee1d91d0-fe13-446e-b21d-44867b78b05d" />